### PR TITLE
Typing Lock Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 	<dependency>
 		<groupId>org.apache.commons</groupId>
 		<artifactId>commons-text</artifactId>
-		<version>1.9</version>
+		<version>1.10.0</version>
 	</dependency>
 	
 	<dependency>

--- a/src/main/java/asynchronous/typing/TypingTest.java
+++ b/src/main/java/asynchronous/typing/TypingTest.java
@@ -177,8 +177,18 @@ public class TypingTest extends ListenerAdapter implements Runnable
 
 	public void quitTest()
 	{
-		scheduledStop.cancel(true);
-		concludeTest.run();
+		try
+		{
+			scheduledStop.cancel(true);
+		}
+		catch (NullPointerException e)
+		{
+			System.out.println("[ERROR: TYPINGTEST] Could not quit test. Aborting...");
+		}
+		finally
+		{
+			concludeTest.run();
+		}
 	}
 
 	private Runnable concludeTest = new Runnable()


### PR DESCRIPTION
Whenever the quitTest() method failed due to the scheduledStop Runnable being null, it did not run the concludeTest Runnable, which permanently locked the test in schedulePool. This caused a test to run perpetually in a server, without the ability to quit, until the server host restarted Zyenyo.

These changes allow concludeTest to always run regardless of whether or not scheduledStop is null.