### PR TITLE
feat: migration command

### DIFF
--- a/zyenyo-discord/src/main/java/commands/Administrator.java
+++ b/zyenyo-discord/src/main/java/commands/Administrator.java
@@ -121,6 +121,29 @@ public class Administrator extends ListenerAdapter
 		
 		}
 		
+		else if (Aliases.MIGRATE.contains(args[0].toLowerCase()))
+		{
+
+			Zyenyo.masterThreadPool.submit(new Runnable()
+				{
+					@Override
+					public void run()
+					{
+						channel.sendMessageFormat("Performing Migration...").queue();
+						long startTime = System.currentTimeMillis();
+						try {
+							Database.migrate();
+							channel.sendMessageFormat(
+								"Migration Successful.%nTime taken: %dms",
+								System.currentTimeMillis() - startTime).queue();
+						} catch (Exception e) {
+							System.err.println(e);
+						}
+
+					}
+			});
+		}
+		
 		else if (Aliases.RESTART.contains(args[0].toLowerCase()))
 		{
 			channel.sendMessageFormat("A restart has been scheduled.").queue();

--- a/zyenyo-discord/src/main/java/dataStructures/Aliases.java
+++ b/zyenyo-discord/src/main/java/dataStructures/Aliases.java
@@ -73,6 +73,7 @@ public final class Aliases
 	/*————————————————————————————————————|
 	|————————————————ADMIN————————————————|
 	|————————————————————————————————————*/
+	public final static Set<String> MIGRATE = Collections.singleton(BotConfig.PREFIX + "migrate");
 	public final static Set<String> SHUTDOWN = Collections.singleton(BotConfig.PREFIX + "shutdown");
 	public final static Set<String> RESTART = Collections.singleton(BotConfig.PREFIX + "restart");
 	public final static Set<String> ADDTEST = Collections.singleton(BotConfig.PREFIX + "addtest");

--- a/zyenyo-discord/src/main/java/zyenyo/Database.java
+++ b/zyenyo-discord/src/main/java/zyenyo/Database.java
@@ -108,7 +108,7 @@ public class Database
 				.append("timeTaken", submission.timeTakenMillis())
 				.append("prompt", submission.promptTitle())
 				.append("submittedText", submission.userTypingSubmission())
-				.append("date", LocalDateTime.now())
+				.append("date", Instant.now())
 				.append("channelId", submission.channelId())
 				);
 
@@ -365,4 +365,6 @@ public class Database
 			);
 		}
 	}
+
+	public static void migrate() throws Exception {}
 }


### PR DESCRIPTION
migration template command added

changed test date from classic `Date()` to java `Instant`, which actually holds timezone information. Luckily this did not really require a migration