### PR TITLE
Seizoxu/db query optimization

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,6 +34,6 @@ jobs:
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
-      with:
-        working-directory: ./zyenyo-discord
+      run: |
+        cd ./zyenyo-discord
+        mvn com.github.ferstl:depgraph-maven-plugin:4.0.1:graph -DgraphFormat=json

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,3 +35,5 @@ jobs:
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
       uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+      with:
+        working-directory: ./zyenyo-discord

--- a/zyenyo-discord/src/main/java/asynchronous/typing/Chart.java
+++ b/zyenyo-discord/src/main/java/asynchronous/typing/Chart.java
@@ -1,26 +1,19 @@
 package asynchronous.typing;
 
-import java.io.IOException;
+import java.awt.BasicStroke;
 import java.io.File;
-
-import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
-
 import java.util.LinkedHashMap;
 
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.EmbedBuilder;
-
-import org.jfree.chart.JFreeChart; 
-import org.jfree.chart.ChartFactory; 
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.CategoryLabelPositions;
 import org.jfree.chart.plot.CategoryPlot;
-import org.jfree.chart.ChartUtilities; 
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.data.category.DefaultCategoryDataset;
-import org.jfree.chart.axis.CategoryLabelPositions;
 
-import java.awt.BasicStroke;
-
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import zyenyo.Database;
 
 

--- a/zyenyo-discord/src/main/java/asynchronous/typing/CompareTest.java
+++ b/zyenyo-discord/src/main/java/asynchronous/typing/CompareTest.java
@@ -1,7 +1,5 @@
 package asynchronous.typing;
 
-import java.time.Instant;
-
 import org.bson.Document;
 
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -38,7 +36,6 @@ public class CompareTest implements Runnable
 				idStr = event.getAuthor().getId();
 			}
 
-			String messageAuthorName = event.getAuthor().getName();
 			String channelID = event.getChannel().getId();
 
 			Document stats = Database.channelCompare(channelID, idStr);

--- a/zyenyo-discord/src/main/java/asynchronous/typing/RefreshUsers.java
+++ b/zyenyo-discord/src/main/java/asynchronous/typing/RefreshUsers.java
@@ -19,7 +19,6 @@ public class RefreshUsers implements Runnable
 	@Override
 	public void run()
 	{
-		String args[] = event.getMessage().getContentRaw().split("\\s+");
 		channel = event.getChannel();
 		
 		try

--- a/zyenyo-discord/src/main/java/asynchronous/typing/TypeTop.java
+++ b/zyenyo-discord/src/main/java/asynchronous/typing/TypeTop.java
@@ -1,10 +1,6 @@
 package asynchronous.typing;
 
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/zyenyo-discord/src/main/java/dataStructures/LeaderboardConfig.java
+++ b/zyenyo-discord/src/main/java/dataStructures/LeaderboardConfig.java
@@ -44,7 +44,6 @@ public class LeaderboardConfig {
 						this.lbStatistic = "totalTp";
 						this.collection = old ?"users" : "usersv2";
 						this.accumulators.add(Accumulators.sum(this.lbStatistic, "$" + this.lbStatistic));
-						this.accumulators.add(Accumulators.first("userTag", "$userTag"));
 						break;
 					case AVERAGE:
 						this.accumulators.add(Accumulators.avg(this.lbStatistic, "$" + this.lbStatistic));

--- a/zyenyo-discord/src/main/java/zyenyo/Database.java
+++ b/zyenyo-discord/src/main/java/zyenyo/Database.java
@@ -1,19 +1,15 @@
 package zyenyo;
 
-import static com.mongodb.client.model.Sorts.descending;
 import static com.mongodb.client.model.Sorts.ascending;
+import static com.mongodb.client.model.Sorts.descending;
 
 import java.time.Instant;
-import java.time.Period;
 import java.time.ZoneId;
-import java.time.temporal.ChronoField;
-import java.time.temporal.ChronoUnit;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -36,9 +32,9 @@ import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.InsertOneResult;
+import com.mongodb.client.result.UpdateResult;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandListener;
-import com.mongodb.client.result.UpdateResult;
 
 import dataStructures.AddTestResult;
 import dataStructures.LeaderboardConfig;


### PR DESCRIPTION
Since all Discord tags are now normalized to have no discriminators, it's sensible to query our own database instead of individually pinging Discord 20 times per leaderboard generation (which takes an average of 10-15 seconds these days).

Uncached users will still return a tag with #0000 appended, since we are still using JDA 4. It's also a primitive way of informing us of uncached users for the time being; we should look towards improving that.

I also removed some unused imports throughout the project.